### PR TITLE
Bind C-c C-o instead of C-c o

### DIFF
--- a/play-routes-mode.el
+++ b/play-routes-mode.el
@@ -51,7 +51,7 @@
 
 (defvar play-routes-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-c o") 'play-routes-open-route)
+    (define-key map (kbd "C-c C-o") 'play-routes-open-route)
     map)
      "Keymap for `play-routes-mode'.")
 


### PR DESCRIPTION
C-c o is reserved for user bindings; major modes must never bind "C-c <letter>".

By the way, the code style is somewhat unusual for Emacs Lisp…
